### PR TITLE
Add release workflow and update AWS credentials provider chain

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🎁 새로운 기능'
+    label: 'feature'
+  - title: '🐞 버그 수정'
+    label: 'fix'
+  - title: '⬆️ Dependencies'
+    collapse-after: 3
+    labels:
+      - 'dependencies'
+change-template: '- $TITLE (#$NUMBER by @$AUTHOR)'
+change-title-escapes: '\<*_&'
+template: |
+  ## Change Logs
+  ---
+  $CHANGES
+no-changes-template: '변경사항이 없습니다.'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+default: patch
+include-labels:
+  - 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+#file: noinspection SpellCheckingInspection
+name: Build
+on:
+  push:
+    tags:
+      - 'release/*'
+jobs:
+  release_draft:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: codeartifact publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          TZ: Asia/Seoul
+        run: ./gradlew publishPlugins --stacktrace --exclude-task test
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=0.0.2
+releaseVersion=0.0.3
 
 kotlin.code.style=official
 kotlinVersion=1.9.24

--- a/src/main/kotlin/com/kmong/Credentials.kt
+++ b/src/main/kotlin/com/kmong/Credentials.kt
@@ -1,17 +1,14 @@
 package com.kmong
 
-import software.amazon.awssdk.auth.credentials.AwsCredentials
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
-import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
-import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.auth.credentials.*
 
 fun getAwsCredentials(profileName: String?): AwsCredentials {
     return AwsCredentialsProviderChain.builder()
+        .addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+        .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
         .addCredentialsProvider(ProfileCredentialsProvider.create(profileName))
-        .addCredentialsProvider(DefaultCredentialsProvider.create())
         .addCredentialsProvider(ContainerCredentialsProvider.create())
         .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+        .addCredentialsProvider(DefaultCredentialsProvider.create())
         .build().resolveCredentials()
 }


### PR DESCRIPTION
### TL;DR

Added GitHub release automation workflow and updated AWS credential provider chain.

### What changed?

- Added release automation with GitHub Actions:
  - Created `.github/release-drafter-config.yml` to define release notes format with Korean category labels
  - Added `.github/workflows/release.yml` to automate plugin publishing when release tags are pushed
- Updated AWS credential provider chain in `Credentials.kt` to include:
  - Added `WebIdentityTokenFileCredentialsProvider` as first priority
  - Added `EnvironmentVariableCredentialsProvider` as second priority
  - Reordered credential providers for better precedence
- Bumped version from 0.0.2 to 0.0.3 in `gradle.properties`

### How to test?

1. Push a tag with format `release/*` to trigger the release workflow
2. Verify the release draft is created with proper categorization
3. Test AWS credential resolution in different environments to ensure proper provider precedence

### Why make this change?

- Streamlines the release process with automated changelog generation and plugin publishing
- Improves AWS credential resolution by adding support for web identity tokens and environment variables
- Enhances security by prioritizing more secure credential providers in the chain