### PR TITLE
feat: credentials sort

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-releaseVersion=0.0.3
+releaseVersion=0.0.4
 
 kotlin.code.style=official
 kotlinVersion=1.9.24

--- a/src/main/kotlin/com/kmong/Credentials.kt
+++ b/src/main/kotlin/com/kmong/Credentials.kt
@@ -6,9 +6,9 @@ fun getAwsCredentials(profileName: String?): AwsCredentials {
     return AwsCredentialsProviderChain.builder()
         .addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
         .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
-        .addCredentialsProvider(ProfileCredentialsProvider.create(profileName))
         .addCredentialsProvider(ContainerCredentialsProvider.create())
         .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+        .addCredentialsProvider(ProfileCredentialsProvider.create(profileName))
         .addCredentialsProvider(DefaultCredentialsProvider.create())
         .build().resolveCredentials()
 }

--- a/src/main/kotlin/com/kmong/codeartifact/CodeArtifactPlugin.kt
+++ b/src/main/kotlin/com/kmong/codeartifact/CodeArtifactPlugin.kt
@@ -5,7 +5,6 @@ import com.kmong.codeartifact.model.CodeArtifactEndpoint.Companion.toEndpoint
 import com.kmong.codeartifact.model.CodeArtifactEndpoint.Companion.toEndpointOrNull
 import com.kmong.getAwsCredentials
 import com.kmong.queryParameters
-import com.kmong.resolveSystemVar
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -118,13 +117,10 @@ abstract class CodeArtifactPlugin @Inject constructor() : Plugin<PluginAware> {
         contract { returns(true) implies (repository is DefaultMavenArtifactRepository) }
         if (repository !is DefaultMavenArtifactRepository) return false
 
-        val domainRegex = resolveSystemVar("codeartifact.domains")?.toRegex() ?: Regex(".*")
-
         val endpoint = repository.url.toEndpointOrNull()
         return when {
             endpoint == null -> false
-            domainRegex.matches(endpoint.domain) -> true
-            else -> false
+            else -> true
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Reordered AWS credential providers and removed domain regex filtering for CodeArtifact repositories.

### What changed?

- Bumped `releaseVersion` from `0.0.3` to `0.0.4`
- Reordered AWS credential providers in `getAwsCredentials()` function, moving `ProfileCredentialsProvider` after `ContainerCredentialsProvider` and `InstanceProfileCredentialsProvider`
- Removed the domain regex filtering logic in the `isCodeArtifactRepository()` function, so all valid CodeArtifact endpoints are now recognized without additional filtering

### How to test?

1. Verify that AWS credential resolution works correctly in different environments
2. Confirm that all CodeArtifact repositories are properly recognized without needing to set the `codeartifact.domains` system variable

### Why make this change?

The credential provider reordering improves the AWS authentication flow by prioritizing container and instance profile credentials before profile credentials. Removing the domain regex filtering simplifies the repository recognition logic, eliminating the need for additional configuration through system variables.